### PR TITLE
unifying opt call into a typed get

### DIFF
--- a/src/main/scala/com/github/andyglow/config/package.scala
+++ b/src/main/scala/com/github/andyglow/config/package.scala
@@ -1,7 +1,9 @@
 package com.github.andyglow
 
 import com.typesafe.config._
-import scala.concurrent.duration.{FiniteDuration, Duration}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.{Duration, FiniteDuration}
 
 package object config {
 
@@ -9,28 +11,41 @@ package object config {
 
   case class Bytes(value: Long)
 
-  implicit val stringGetter: Getter[String]               = _ getString _
-  implicit val booleanGetter: Getter[Boolean]             = _ getBoolean _
-  implicit val intGetter: Getter[Int]                     = _ getInt _
-  implicit val doubleGetter: Getter[Double]               = _ getDouble _
-  implicit val longGetter: Getter[Long]                   = _ getLong _
-  implicit val bytesGetter: Getter[Bytes]                 = (c, p) => Bytes(c getBytes p)
-  implicit val durationGetter: Getter[Duration]           = (c, p) => Duration.fromNanos((c getDuration p).toNanos)
-  implicit val finiteDurationGetter: Getter[FiniteDuration] = (c, p) => Duration.fromNanos((c getDuration p).toNanos)
-  implicit val configListGetter: Getter[ConfigList]       = _ getList _
-  implicit val configGetter: Getter[Config]               = _ getConfig _
-  implicit val objectGetter: Getter[ConfigObject]         = _ getObject _
-  implicit val memorySizeGetter: Getter[ConfigMemorySize] = _ getMemorySize _
+  implicit val stringGetter: Getter[String]                   = _ getString _
+  implicit val booleanGetter: Getter[Boolean]                 = _ getBoolean _
+  implicit val intGetter: Getter[Int]                         = _ getInt _
+  implicit val doubleGetter: Getter[Double]                   = _ getDouble _
+  implicit val longGetter: Getter[Long]                       = _ getLong _
+  implicit val bytesGetter: Getter[Bytes]                     = (c, p) => Bytes(c getBytes p)
+  implicit val durationGetter: Getter[Duration]               = (c, p) => Duration.fromNanos((c getDuration p).toNanos)
+  implicit val finiteDurationGetter: Getter[FiniteDuration]   = (c, p) => Duration.fromNanos((c getDuration p).toNanos)
+  implicit val configListGetter: Getter[ConfigList]           = _ getList _
+  implicit val configGetter: Getter[Config]                   = _ getConfig _
+  implicit val objectGetter: Getter[ConfigObject]             = _ getObject _
+  implicit val memorySizeGetter: Getter[ConfigMemorySize]     = _ getMemorySize _
+  implicit val configListStringGetter: Getter[List[String]]   = (config, path) => config.getStringList(path).asScala.toList
+  implicit val configListBooleanGetter: Getter[List[Boolean]] = (config, path) => config.getBooleanList(path).asScala.toList.map(_.booleanValue())
+  implicit val longListBooleanGetter: Getter[List[Long]]      = (config, path) => config.getLongList(path).asScala.toList.map(_.longValue())
+  implicit val configListIntGetter: Getter[List[Int]]         = (config, path) => config.getIntList(path).asScala.toList.map(_.toInt)
 
-  implicit class ConfigOps(val config: Config) extends AnyVal {
-    def getOrElse[T : Getter](path: String, defValue: => T): T = opt[T](path) getOrElse defValue
-    def opt[T : Getter](path: String): Option[T] = {
-      if (config hasPathOrNull path) {
-        val getter = implicitly[Getter[T]]
-        Some(getter(config, path))
-      } else
-        None
-    }
+  implicit def optionGetter[T](implicit getter: Getter[T]): Getter[Option[T]] = { (config, path) =>
+    if (config hasPathOrNull path) {
+      Some(getter(config, path))
+    } else
+      None
   }
 
+  /**
+    * enriches Typesafe configuration functionality with custom scala typesafe operations.
+    */
+  implicit class ConfigOps(val config: Config) extends AnyVal {
+
+    def getOrElse[T: Getter](path: String, defValue: => T)(implicit getter: Getter[Option[T]]): T =
+      getter(config, path) getOrElse defValue
+
+    def get[T: Getter](path: String): T = {
+      val getter = implicitly[Getter[T]]
+      getter(config, path)
+    }
+  }
 }

--- a/src/test/scala/com/github/andyglow/config/ConfigExtSpec.scala
+++ b/src/test/scala/com/github/andyglow/config/ConfigExtSpec.scala
@@ -28,67 +28,67 @@ class ConfigExtSpec extends WordSpec with Matchers {
 
   "Config extension" should {
     "work with strings" in {
-      config.opt[String]("string") shouldBe Some("foo")
-      config.opt[String]("absent") shouldBe None
+      config.get[String]("string") shouldBe Some("foo")
+      config.get[Option[String]]("absent") shouldBe None
       config.getOrElse("string", "orElse") shouldBe "foo"
       config.getOrElse("absent", "orElse") shouldBe "orElse"
     }
     "work with booleans" in {
-      config.opt[Boolean]("boolean") shouldBe Some(true)
-      config.opt[Boolean]("absent") shouldBe None
+      config.get[Option[Boolean]]("boolean") shouldBe Some(true)
+      config.get[Option[Boolean]]("absent") shouldBe None
       config.getOrElse("boolean", false) shouldBe true
       config.getOrElse("absent", true) shouldBe true
       config.getOrElse("absent", false) shouldBe false
     }
     "work with ints" in {
-      config.opt[Int]("int") shouldBe Some(5)
-      config.opt[Int]("absent") shouldBe None
+      config.get[Option[Int]]("int") shouldBe Some(5)
+      config.get[Option[Int]]("absent") shouldBe None
       config.getOrElse("int", 11) shouldBe 5
       config.getOrElse("absent", 11) shouldBe 11
     }
     "work with doubles" in {
-      config.opt[Double]("double") shouldBe Some(5.7)
-      config.opt[Double]("absent") shouldBe None
+      config.get[Option[Double]]("double") shouldBe Some(5.7)
+      config.get[Option[Double]]("absent") shouldBe None
       config.getOrElse("double", 11.34) shouldBe 5.7
       config.getOrElse("absent", 11.34) shouldBe 11.34
     }
     "work with longs" in {
-      config.opt[Long]("long") shouldBe Some(9865764764534l)
-      config.opt[Long]("absent") shouldBe None
+      config.get[Option[Long]]("long") shouldBe Some(9865764764534l)
+      config.get[Option[Long]]("absent") shouldBe None
       config.getOrElse("long", 77l) shouldBe 9865764764534l
       config.getOrElse("absent", 77l) shouldBe 77
     }
     "work with bytes" in {
-      config.opt[Bytes]("bytes") shouldBe Some(Bytes(134217728))
-      config.opt[Bytes]("absent") shouldBe None
+      config.get[Option[Bytes]]("bytes") shouldBe Some(Bytes(134217728))
+      config.get[Option[Bytes]]("absent") shouldBe None
       config.getOrElse("bytes", Bytes(56)) shouldBe Bytes(134217728)
       config.getOrElse("absent", Bytes(56)) shouldBe Bytes(56)
     }
     "work with durations" in {
-      config.opt[Duration]("duration") shouldBe Some(7.seconds)
-      config.opt[Duration]("absent") shouldBe None
+      config.get[Option[Duration]]("duration") shouldBe Some(7.seconds)
+      config.get[Option[Duration]]("absent") shouldBe None
       config.getOrElse("duration", 15.minutes) shouldBe 7.seconds
       config.getOrElse("absent", 15.minutes) shouldBe 15.minutes
     }
     "work with config lists" in {
-      config.opt[ConfigList]("configList") shouldBe 'defined
-      config.opt[ConfigList]("configList").value.unwrapped().asScala shouldBe List(15, "bar")
-      config.opt[ConfigList]("absent") shouldBe None
+      config.get[Option[ConfigList]]("configList") shouldBe 'defined
+      config.get[Option[ConfigList]]("configList").value.unwrapped().asScala shouldBe List(15, "bar")
+      config.get[Option[ConfigList]]("absent") shouldBe None
     }
     "work with configs" in {
-      config.opt[Config]("config") shouldBe 'defined
-      config.opt[Config]("config").value.hasPath("bar") shouldBe true
-      config.opt[Config]("config").value.getString("bar") shouldBe "baz"
-      config.opt[Config]("absent") shouldBe None
+      config.get[Option[Config]]("config") shouldBe 'defined
+      config.get[Option[Config]]("config").value.hasPath("bar") shouldBe true
+      config.get[Option[Config]]("config").value.getString("bar") shouldBe "baz"
+      config.get[Option[Config]]("absent") shouldBe None
     }
     "work with config objects" in {
-      config.opt[ConfigObject]("configObject") shouldBe 'defined
-      config.opt[ConfigObject]("configObject").value.unwrapped().asScala shouldBe Map("x" -> 99)
-      config.opt[ConfigObject]("absent") shouldBe None
+      config.get[Option[ConfigObject]]("configObject") shouldBe 'defined
+      config.get[Option[ConfigObject]]("configObject").value.unwrapped().asScala shouldBe Map("x" -> 99)
+      config.get[Option[ConfigObject]]("absent") shouldBe None
     }
     "work with memory sizes" in {
-      config.opt[ConfigMemorySize]("memorySize") shouldBe Some(ConfigMemorySize.ofBytes(2048))
-      config.opt[ConfigMemorySize]("absent") shouldBe None
+      config.get[Option[ConfigMemorySize]]("memorySize") shouldBe Some(ConfigMemorySize.ofBytes(2048))
+      config.get[Option[ConfigMemorySize]]("absent") shouldBe None
       config.getOrElse("memorySize", ConfigMemorySize.ofBytes(1024)) shouldBe ConfigMemorySize.ofBytes(2048)
       config.getOrElse("absent", ConfigMemorySize.ofBytes(1024)) shouldBe ConfigMemorySize.ofBytes(1024)
     }


### PR DESCRIPTION
I think your extensions are very good, providing a good layer of abstraction over typesafe config, without introducing too much overhead.
I've changed it slightly removing the ` opt ` call generalizing to a typed call `get[Option[Something]]`
Tell me if you think this change is worth to be merged of if you prefer the other way around.
